### PR TITLE
Fix missing React type import in selection translation hook

### DIFF
--- a/hooks/useSelectionTranslation.ts
+++ b/hooks/useSelectionTranslation.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, type RefObject } from 'react';
 import { useVocabulary } from '../contexts/VocabularyContext';
 
 interface SelectionInfo {
@@ -6,7 +6,7 @@ interface SelectionInfo {
   position: { top: number; left: number };
 }
 
-export const useSelectionTranslation = (containerRef: React.RefObject<HTMLElement>) => {
+export const useSelectionTranslation = (containerRef: RefObject<HTMLElement>) => {
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const { addVocabWord, isLoading } = useVocabulary();
   


### PR DESCRIPTION
## Summary
- import `RefObject` from React to fix missing namespace error
- use `RefObject` type in `useSelectionTranslation` hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68965d35fc8c8321a6237f095359c547