### PR TITLE
Rename SendHorizonal icon to SendHorizontal

### DIFF
--- a/components/DialoguePractice.tsx
+++ b/components/DialoguePractice.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { createDialogueChat } from '../services/geminiService';
 import { LoadingSpinner } from './LoadingSpinner';
-import { SendHorizonal } from './Icons';
+import { SendHorizontal } from './Icons';
 import { TranslationPopup } from './TranslationPopup';
 import { useSelectionTranslation } from '../hooks/useSelectionTranslation';
 import type { Chat } from '@google/genai';
@@ -130,7 +130,7 @@ export const DialoguePractice: React.FC = () => {
                 className="flex items-center justify-center bg-indigo-600 text-white font-semibold rounded-lg px-4 py-2 hover:bg-indigo-700 transition-colors disabled:bg-indigo-400 disabled:cursor-not-allowed"
                 disabled={isLoading || !userInput.trim()}
                 >
-                <SendHorizonal className="w-5 h-5" />
+                <SendHorizontal className="w-5 h-5" />
                 </button>
             </form>
         </>

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -29,7 +29,7 @@ export const Feather: React.FC<{className?: string}> = ({ className }) => (
     </svg>
 );
 
-export const SendHorizonal: React.FC<{className?: string}> = ({ className }) => (
+export const SendHorizontal: React.FC<{className?: string}> = ({ className }) => (
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
         <path d="m3 3 3 9-3 9 19-9Z"/>
         <path d="M6 12h16"/>

--- a/components/RpgMode.tsx
+++ b/components/RpgMode.tsx
@@ -5,7 +5,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { createRpgChat } from '../services/geminiService';
 import { LoadingSpinner } from './LoadingSpinner';
-import { SendHorizonal, Shield, Play, Pause, SkipBack, SkipForward, Users } from './Icons';
+import { SendHorizontal, Shield, Play, Pause, SkipBack, SkipForward, Users } from './Icons';
 import { TranslationPopup } from './TranslationPopup';
 import { SpeechHighlighting } from './SpeechHighlighting';
 import { useVocabulary } from '../contexts/VocabularyContext';
@@ -617,7 +617,7 @@ export const RpgMode: React.FC = () => {
                     disabled={isLoading || !userInput.trim()}
                     aria-label="Send action"
                 >
-                    <SendHorizonal className="w-5 h-5" />
+                    <SendHorizontal className="w-5 h-5" />
                 </button>
             </div>
         </form>


### PR DESCRIPTION
## Summary
- fix typo in send icon name from `SendHorizonal` to `SendHorizontal`
- update RpgMode and DialoguePractice to import and render `SendHorizontal`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68965e64e7ec8321b995ca74c7ea922b