### PR TITLE
Fix parseResponse quote handling in RPG mode

### DIFF
--- a/components/RpgMode.tsx
+++ b/components/RpgMode.tsx
@@ -337,7 +337,13 @@ export const RpgMode: React.FC = () => {
       const correctionPrefix = "Correction: ";
       const lines = responseText.split('\n');
       if (lines.length > 0 && lines[0].startsWith(correctionPrefix)) {
-          const correction = lines[0].substring(correctionPrefix.length).trim().slice(1, -1);
+          let correction = lines[0].substring(correctionPrefix.length).trim();
+          if (
+            (correction.startsWith('"') && correction.endsWith('"')) ||
+            (correction.startsWith("'") && correction.endsWith("'"))
+          ) {
+              correction = correction.slice(1, -1);
+          }
           const story = lines.slice(1).join('\n').trim();
           return { correction, story };
       }


### PR DESCRIPTION
## Summary
- Ensure `parseResponse` only strips surrounding quotes from corrections when quotes are present

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node` manual tests for `parseResponse` with quoted and unquoted corrections

------
https://chatgpt.com/codex/tasks/task_e_68965e6907888321845f733b25f84f00